### PR TITLE
Include path in output URL

### DIFF
--- a/privatebin/privatebin.go
+++ b/privatebin/privatebin.go
@@ -183,6 +183,7 @@ func (c *Client) CreatePaste(
 	var uri url.URL
 	uri.Scheme = c.URL.Scheme
 	uri.Host = c.URL.Host
+	uri.Path = c.URL.Path
 	uri.RawQuery = pasteId.RawQuery
 	uri.Fragment = base58.Encode(masterKey)
 


### PR DESCRIPTION
This change will allow hosted privatebins to have paths as part of their URLs (https://mysite.com/privatebin/). Without the patch, the CLI works, but it displays the wrong URL in its output.