### PR TITLE
Feature:custom user agent

### DIFF
--- a/cmd/privatebin/main.go
+++ b/cmd/privatebin/main.go
@@ -43,6 +43,7 @@ type BinCfg struct {
 	OpenDiscussion   *bool   `json:"open_discussion"`
 	BurnAfterReading *bool   `json:"burn_after_reading"`
 	Formatter        string  `json:"formatter"`
+	UserAgent        string   `json:"user_agent"`
 }
 
 type Cfg struct {
@@ -51,12 +52,14 @@ type Cfg struct {
 	OpenDiscussion   bool     `json:"open_discussion"`
 	BurnAfterReading bool     `json:"burn_after_reading"`
 	Formatter        string   `json:"formatter"`
+	UserAgent        string   `json:"user_agent"`
 }
 
 func DefaultCfg() *Cfg {
 	return &Cfg{
 		Expire:    "1day",
 		Formatter: "plaintext",
+		UserAgent: "Privatebin cli +https://github.com/gearnode/privatebin",
 	}
 }
 
@@ -106,6 +109,10 @@ func loadCfgFile(path string) (*Cfg, error) {
 
 		if binCfg.Formatter == "" {
 			binCfg.Formatter = cfg.Formatter
+		}
+
+		if binCfg.UserAgent == "" {
+			binCfg.UserAgent = cfg.UserAgent
 		}
 
 		cfg.Bin[i] = binCfg
@@ -198,6 +205,7 @@ func main() {
 		strings.Join(data, "\n"),
 		binCfg.Expire,
 		binCfg.Formatter,
+		binCfg.UserAgent,
 		*binCfg.OpenDiscussion,
 		*binCfg.BurnAfterReading,
 		*password)

--- a/doc/privatebin.conf.5.md
+++ b/doc/privatebin.conf.5.md
@@ -23,6 +23,9 @@ instance configured in the **config.json**.
 **formatter** *string* (default: "plaintext")
 : The default formatter for a paste.
 
+**user_agent** *string* (default: "privatebin cli +https://github.com/gearnode/privatebin")
+: The default user agent for a paste.
+
 **expire** *string* (default: "1day")
 : The default time to live for a paste.
 
@@ -50,6 +53,9 @@ instance configured in the **config.json**.
 
 **formatter** *string*
 : The formatter for the paste.
+
+**user_agent** *string*
+: The user agent for the paste.
 
 ## The auth object format:
 **username** *string*

--- a/privatebin.go
+++ b/privatebin.go
@@ -100,7 +100,7 @@ type PasteContent struct {
 }
 
 func (c *Client) CreatePaste(
-	message, expire, formatter string,
+	message, expire, formatter string, useragent string,
 	openDiscussion, burnAfterReading bool,
 	password string,
 ) (*CreatePasteResponse, error) {
@@ -141,6 +141,7 @@ func (c *Client) CreatePaste(
 		c.URL.String(),
 		bytes.NewBuffer(body))
 
+	req.Header.Set("User-Agent", useragent)
 	req.Header.Set("Content-Type",
 		"application/x-www-form-urlencoded")
 	req.Header.Set("Content-Length", strconv.Itoa(len(body)))


### PR DESCRIPTION
The default go http client user agent can be blocked by several tool (cloudflare, internal WAF, etc.).
This PR add a default custom user agent for the tool that can be configured from the config file.