### PR TITLE
Add burnAfterReading confirmation prefix in the uri fragment

### DIFF
--- a/privatebin.go
+++ b/privatebin.go
@@ -115,7 +115,7 @@ type PasteMessage struct {
 func (c *Client) CreatePaste(
 	message *PasteMessage,
 	expire, formatter string,
-	openDiscussion, burnAfterReading, gzip bool,
+	openDiscussion, burnAfterReading bool, gzip bool,
 	password string,
 ) (*CreatePasteResponse, error) {
 	masterKey, err := generateRandomBytes(32)
@@ -229,7 +229,11 @@ func (c *Client) CreatePaste(
 	uri.Host = c.URL.Host
 	uri.Path = c.URL.Path
 	uri.RawQuery = pasteId.RawQuery
-	uri.Fragment = base58.Encode(masterKey)
+	if burnAfterReading {
+		uri.Fragment = "-" + base58.Encode(masterKey)
+	} else {
+		uri.Fragment = base58.Encode(masterKey)
+	}
 
 	pasteResponse.URL = uri.String()
 


### PR DESCRIPTION
[Privatebin 1.7.0](https://github.com/PrivateBin/PrivateBin/releases/tag/1.7.0) come with a new feature:
> CHANGED: Ask for confirmation, before loading burn after reading pastes (https://github.com/PrivateBin/PrivateBin/pull/1237)

This works by adding a [prefix](https://github.com/PrivateBin/PrivateBin/blob/a62f4babbf14fde8380294a54a9c47db2a218839/js/privatebin.js#L85) to the uri fragment [when generating the paste url](https://github.com/PrivateBin/PrivateBin/blob/a62f4babbf14fde8380294a54a9c47db2a218839/js/privatebin.js#L4864).
