### PR TITLE
Add binary package for archlinux

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,14 @@ preferred method.
 
 ### Arch Linux
 
+[![privatebin-cli on AUR](https://img.shields.io/aur/version/privatebin-cli?label=privatebin-cli)](https://aur.archlinux.org/packages/privatebin-cli/)
+[![privatebin-cli-bin on AUR](https://img.shields.io/aur/version/privatebin-cli-bin?label=privatebin-cli-bin)](https://aur.archlinux.org/packages/privatebin-cli-bin/)
+
 Available on the Arch User Repository (AUR). Install using your
 favorite AUR helper:
 
 - [privatebin-cli](https://aur.archlinux.org/packages/privatebin-cli/) - Release package
+- [privatebin-cli-bin](https://aur.archlinux.org/packages/privatebin-cli-bin) - Binary package
 
 #### Example Installation:
 


### PR DESCRIPTION
Hey !

Thanks for the binary release.
I've made a new package to use it.

Also added some images for the archlinux packages version:
[![privatebin-cli on AUR](https://img.shields.io/aur/version/privatebin-cli?label=privatebin-cli)](https://aur.archlinux.org/packages/privatebin-cli/)
[![privatebin-cli-bin on AUR](https://img.shields.io/aur/version/privatebin-cli-bin?label=privatebin-cli-bin)](https://aur.archlinux.org/packages/privatebin-cli-bin/)
