### PR TITLE
Trim trailing `/` from the config host before comparing hosts and declaring them different

### DIFF
--- a/cmd/privatebin/main.go
+++ b/cmd/privatebin/main.go
@@ -157,7 +157,7 @@ var (
 				return fmt.Errorf("cannot parse paste url: %w", err)
 			}
 
-			if link.Scheme+"://"+link.Host != binCfg.Host {
+			if link.Scheme+"://"+link.Host != strings.TrimRight(binCfg.Host, "/") {
 				if !insecure {
 					return fmt.Errorf("untrusted privatebin instance use --insecure flag or add it to the configuration")
 				}


### PR DESCRIPTION
Before this fix, if the host in the config has a trailing `/`, `pastebin show` will incorrectly complain, `untrusted privatebin instance use --insecure flag [...]`.
Trimming a trailing `/` fixes that issue.