### PR TITLE
decrypt: Attempt to use a `NewGCM()` without specifying nonce and tag size before bailing.

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -94,7 +94,7 @@ type gcmAble interface {
 	NewGCM(nonceSize, tagSize int) (cipher.AEAD, error)
 }
 
-func newGCMWithNonceAndTagSize(cipher cipher.Block, nonceSize, tagSize int) (cipher.AEAD, error) {
+func newGCMWithNonceAndTagSize(block cipher.Block, nonceSize, tagSize int) (cipher.AEAD, error) {
 	if tagSize < gcmMinimumTagSize || tagSize > gcmBlockSize {
 		return nil, errors.New("cipher: incorrect tag size given to GCM")
 	}
@@ -103,9 +103,10 @@ func newGCMWithNonceAndTagSize(cipher cipher.Block, nonceSize, tagSize int) (cip
 		return nil, errors.New("cipher: the nonce can't have zero length, or the security of the key will be immediately compromised")
 	}
 
-	if cipher, ok := cipher.(gcmAble); ok {
-		return cipher.NewGCM(nonceSize, tagSize)
+	if block, ok := block.(gcmAble); ok {
+		return block.NewGCM(nonceSize, tagSize)
 	}
-
-	panic("non GCM crypto is not supported")
+	// Attempt to use cipher.NewGCM() before giving up.
+	// This matches the encrypt logic and works fine for some privatebin implementations.
+	return cipher.NewGCM(block)
 }


### PR DESCRIPTION
The current code fails to decrypt messages from privatebin.net and private (unnamed) sites tested.

Using `cipher.NewGCM(block)` successfully decrypts messages from said sites. It may not always work, but it certainly works in more scenarios with more privatebin sites.