### PR TITLE
doc: Add brew to install possibilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ your workflow, enabling swift creation and management of pastes.
 managers, or from source. Follow the instructions below for your
 preferred method.
 
-### macOS
+### macOS & Lnux w. `brew`
 
 ```
 brew install privatebin-cli


### PR DESCRIPTION
As per of
- https://github.com/gearnode/privatebin/issues/18

I thought it would make sens to let know people that the install experience is the same for Mac users than for Linux ones.