### PR TITLE
Support falling back to a system-wide configuration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Attempt to read a global system configuration file if `~/.config/privatebin/config.json` is not found. On Windows, `C:\ProgramData\privatebin\config.json` and on other operating systems, `/etc/privatebin/config.json`.
+
 ## [2.1.1] - 2025-09-08
 
 ### Fixed

--- a/doc/privatebin.1.md
+++ b/doc/privatebin.1.md
@@ -30,6 +30,8 @@ instances.
 **-c, -\-config** \<path\>
 : The path of the configuration file (default
   "~/.config/privatebin/config.json").
+  If not found, the CLI will also look for a system-wide configuration file at
+  "/etc/privatebin/config.json" (Linux/macOS) or "C:\\ProgramData\\privatebin\\config.json" (Windows).
 
 **-H, -\-header** \<key=value\>
 : The extra HTTP header fields to include in the request sent.

--- a/doc/privatebin.conf.5.md
+++ b/doc/privatebin.conf.5.md
@@ -124,8 +124,13 @@ A bit more complete configuration file:
 # FILES
 
 _~/.config/privatebin/config.json_
-: Default location of the privatebin configuration. The file has to be
-created manually as it is not installed with a standard installation.
+: Default location of the privatebin configuration. The file has to be created manually as it is not installed with a standard installation.
+
+_/etc/privatebin/config.json_ (Linux/macOS)
+: System-wide configuration file location, used if the user config is not found.
+
+_C:\\ProgramData\\privatebin\\config.json_ (Windows)
+: System-wide configuration file location, used if the user config is not found.
 
 # AUTHORS
 


### PR DESCRIPTION
For easier management on multi-user systems, the PrivateBin CLI tool should to fall back to a system-wide configuration file when it can't find a user-specific one at `~/.config/privatebin`

Tested on macOS and Linux. I do not have easy access to a Windows machine.